### PR TITLE
Dev

### DIFF
--- a/modules/links/links.go
+++ b/modules/links/links.go
@@ -83,6 +83,7 @@ func (l *links) getLinkTitle(link string) (string, error) {
 }
 
 func formatResponse(link string) string {
+	link = strings.Replace(link, "\n", "", -1)
 	return fmt.Sprintf("[ %s ]", link)
 }
 


### PR DESCRIPTION
twitter (and others?) keeps control codes intact in their page titles, newlines cut glitzz off mid-string